### PR TITLE
feat: Enhance functionality and config options

### DIFF
--- a/automations/scene-cycle-button.yaml
+++ b/automations/scene-cycle-button.yaml
@@ -38,13 +38,13 @@ blueprint:
           multiple: false
     target_area:
       name: Area
-      description: This area will be controlled by the button.
+      description: This area's lights will be controlled by the button.
       selector:
         area:
           multiple: false
     scene_state_counter_helper:
       name: Scene state counter helper
-      description: Define a counter helper which stores the number of clicks in a row.
+      description: Define a counter helper which stores the number of clicks in a row. This is needed to cycle through the scenes.
       selector:
         entity:
           filter:
@@ -68,7 +68,7 @@ blueprint:
         seconds: 3
     action_long_press:
       name: Action on long button press
-      description: Define an action to perform when button is double-pressed.
+      description: Define an action to perform when triggered by a long button press.
       default: Dim lights
       selector:
         select:

--- a/automations/scene-cycle-button.yaml
+++ b/automations/scene-cycle-button.yaml
@@ -1,6 +1,7 @@
 blueprint:
   name: Scene Cycle Button
-  description: "Switch between multiple scenes on Philips Hue button clicks.
+  description:
+    "Switch between multiple scenes on Philips Hue Smart button clicks.
     Supports long press, double press, and triple press actions as well."
   domain: automation
   author: Tim-Jonas Schwarz

--- a/automations/scene-cycle-button.yaml
+++ b/automations/scene-cycle-button.yaml
@@ -36,13 +36,6 @@ blueprint:
               model: ROM001
               manufacturer: Philips
           multiple: false
-    target_light:
-      name: Lights
-      description: These lights will be controlled by the button.
-      selector:
-        entity:
-          domain: light
-          multiple: false
     target_area:
       name: Area
       description: This area will be controlled by the button.
@@ -147,7 +140,7 @@ action:
                     target:
                       entity_id: "{{ scenes_default[0] }}"
                     data:
-                      transition: 0.1
+                      transition: 0
                   - service: counter.set_value
                     target:
                       entity_id: "{{ scene_state_counter_helper }}"
@@ -158,7 +151,7 @@ action:
                     target:
                       entity_id: "{{ next_scene }}"
                     data:
-                      transition: 0.1
+                      transition: 0
                   - service: counter.increment
                     target:
                       entity_id: "{{ scene_state_counter_helper }}"
@@ -209,14 +202,25 @@ action:
                         target:
                           area_id: "{{ target_area }}"
                     else:
-                      - service: light.turn_on
-                        data_template:
-                          entity_id: !input target_light
-                          transition: "0.7"
-                          brightness: "{% if not brightness == None
-                            %} {% set n = brightness + 25 %} {% if
-                            n > 255 %}\n  255\n{% else %}\n  {{ n }}\n{% endif %} {% else %}  25
-                            \ {% endif %}\n"
+                      - repeat:
+                          for_each: "{{ target_lights }}"
+                          sequence:
+                            service: light.turn_on
+                            data_template:
+                              entity_id: "{{ repeat.item }}"
+                              transition: >-
+                                {% if states(repeat.item) == 'off' %}
+                                  0
+                                {% else %}
+                                  0.7
+                                {% endif %}
+                              brightness: >-
+                                {% set entity_brightness = state_attr(repeat.item, 'brightness') %}
+                                {% if not entity_brightness == None %}
+                                  {{ [entity_brightness + 25, 255] | min }}
+                                {% else %}
+                                  25
+                                {% endif %}
       - conditions:
           - condition: trigger
             id:
@@ -229,7 +233,6 @@ action:
         sequence: !input action_triple_press
 mode: restart
 variables:
-  target_light: !input "target_light"
   target_area: !input "target_area"
   scene_state_counter_helper: !input "scene_state_counter_helper"
   scenes_default: !input "scenes_default"
@@ -240,5 +243,5 @@ variables:
   target_lights: "{{ area_entities(target_area) | select('match', '^light\\..+') | list }}"
   target_lights_on: "{{ expand(target_lights) | selectattr('state', 'eq', 'on') | list }}"
   is_light_off: "{{ target_lights_on | count == 0 }}"
-  brightness: "{{ state_attr(target_light, 'brightness') }}"
+  brightness: "{{ target_lights | map('state_attr', 'brightness') | reject('==', None) | list | average(0) | round | int }}"
   button_press_timeout_seconds: "{{ [button_press_timeout.hours * 3600, button_press_timeout.minutes * 60, button_press_timeout.seconds] | sum }}"

--- a/automations/scene-cycle-button.yaml
+++ b/automations/scene-cycle-button.yaml
@@ -48,13 +48,21 @@ blueprint:
       selector:
         area:
           multiple: false
-    scenes:
-      name: Scenes input select
-      description: Define an input select with the scenes to cycle through on button press.
+    scene_state_counter_helper:
+      name: Scene state counter helper
+      description: Define a counter helper which stores the number of clicks in a row.
       selector:
         entity:
           filter:
-            - domain: input_select
+            - domain: counter
+    scenes_default:
+      name: Scenes
+      description: Define the scenes to cycle through on button press.
+      selector:
+        entity:
+          filter:
+            - domain: scene
+          multiple: true
     button_press_timeout:
       name: Button press timeout
       description: The time window in which a button press after a previous button one switches to the next scene.
@@ -134,20 +142,25 @@ action:
                     value_template: "{{ is_light_off }}"
                     alias: Check if target lights are off
                 then:
-                  - service: input_select.select_first
+                  - service: scene.turn_on
                     target:
-                      entity_id: "{{ scenes }}"
-                else:
-                  - service: input_select.select_next
-                    target:
-                      entity_id: "{{ scenes }}"
+                      entity_id: "{{ scenes_default[0] }}"
                     data:
-                      cycle: true
-              - service: scene.turn_on
-                target:
-                  entity_id: "{{ states(scenes) }}"
-                data:
-                  transition: 0.1
+                      transition: 0.1
+                  - service: counter.set_value
+                    target:
+                      entity_id: "{{ scene_state_counter_helper }}"
+                    data:
+                      value: 1
+                else:
+                  - service: scene.turn_on
+                    target:
+                      entity_id: "{{ next_scene }}"
+                    data:
+                      transition: 0.1
+                  - service: counter.increment
+                    target:
+                      entity_id: "{{ scene_state_counter_helper }}"
             else:
               - service: light.turn_off
                 metadata: {}
@@ -217,11 +230,14 @@ mode: restart
 variables:
   target_light: !input "target_light"
   target_area: !input "target_area"
-  scenes: !input "scenes"
-  brightness: "{{state_attr(target_light, 'brightness')}}"
+  scene_state_counter_helper: !input "scene_state_counter_helper"
+  scenes_default: !input "scenes_default"
   action_long_press: !input "action_long_press"
   button_press_timeout: !input "button_press_timeout"
+  scene_state_counter_value: "{{ states(scene_state_counter_helper) | int }}"
+  next_scene: "{{ scenes_default[scene_state_counter_value % scenes_default|length] }}"
   target_lights: "{{ area_entities(target_area) | select('match', '^light\\..+') | list }}"
   target_lights_on: "{{ expand(target_lights) | selectattr('state', 'eq', 'on') | list }}"
   is_light_off: "{{ target_lights_on | count == 0 }}"
+  brightness: "{{ state_attr(target_light, 'brightness') }}"
   button_press_timeout_seconds: "{{ [button_press_timeout.hours * 3600, button_press_timeout.minutes * 60, button_press_timeout.seconds] | sum }}"

--- a/automations/scene-cycle-button.yaml
+++ b/automations/scene-cycle-button.yaml
@@ -66,6 +66,15 @@ blueprint:
         hours: 0
         minutes: 0
         seconds: 3
+    start_cycle_scene:
+      name: Start scene cycle with
+      description: Which scene to activate when area lights are off and the button is initially pressed.
+      default: First scene
+      selector:
+        select:
+          options:
+            - First scene
+            - Last active scene
     action_long_press:
       name: Action on long button press
       description: Define an action to perform when triggered by a long button press.
@@ -136,16 +145,28 @@ action:
                     value_template: "{{ is_light_off }}"
                     alias: Check if target lights are off
                 then:
-                  - service: scene.turn_on
-                    target:
-                      entity_id: "{{ scenes_default[0] }}"
-                    data:
-                      transition: 0
-                  - service: counter.set_value
-                    target:
-                      entity_id: "{{ scene_state_counter_helper }}"
-                    data:
-                      value: 1
+                  - choose:
+                      - conditions:
+                          - condition: template
+                            value_template: "{{ start_cycle_scene == 'First scene' }}"
+                        sequence:
+                          - service: scene.turn_on
+                            target:
+                              entity_id: "{{ scenes_default[0] }}"
+                            data:
+                              transition: 0
+                          - service: counter.set_value
+                            target:
+                              entity_id: "{{ scene_state_counter_helper }}"
+                            data:
+                              value: 1
+                      - conditions:
+                          - condition: template
+                            value_template: "{{ start_cycle_scene == 'Last active scene' }}"
+                        sequence:
+                          - service: light.turn_on
+                            target:
+                              area_id: "{{ target_area }}"
                 else:
                   - service: scene.turn_on
                     target:
@@ -232,6 +253,7 @@ variables:
   target_area: !input "target_area"
   scene_state_counter_helper: !input "scene_state_counter_helper"
   scenes_default: !input "scenes_default"
+  start_cycle_scene: !input "start_cycle_scene"
   action_long_press: !input "action_long_press"
   button_press_timeout: !input "button_press_timeout"
   scene_state_counter_value: "{{ states(scene_state_counter_helper) | int }}"

--- a/automations/scene-cycle-button.yaml
+++ b/automations/scene-cycle-button.yaml
@@ -150,11 +150,13 @@ action:
                           - condition: template
                             value_template: "{{ start_cycle_scene == 'First scene' }}"
                         sequence:
+                          # Select the very first scene from the scenes list.
                           - service: scene.turn_on
                             target:
                               entity_id: "{{ scenes_default[0] }}"
                             data:
                               transition: 0
+                          # Reset the counter to 1.
                           - service: counter.set_value
                             target:
                               entity_id: "{{ scene_state_counter_helper }}"
@@ -164,9 +166,45 @@ action:
                           - condition: template
                             value_template: "{{ start_cycle_scene == 'Last active scene' }}"
                         sequence:
-                          - service: light.turn_on
+                          # If the counter is 0 (which only happens when the automation runs the very first time with a
+                          # freh counter), we pick the first scene from the default scenes list. Otherwise, we pick the
+                          # last active scene.
+                          - service: scene.turn_on
                             target:
-                              area_id: "{{ target_area }}"
+                              entity_id: >-
+                                {% if scene_state_counter_value == 0 %}
+                                  {{ scenes_default[0] }}
+                                {% else %}
+                                  {{ scenes_default[(scene_state_counter_value - 1) % scenes_default|length] }}
+                                {% endif %}
+                            data:
+                              transition: 0
+                          # Limit counter number to the number of scenes. This does not change the current scene state but
+                          # just avoids the counter to keep growing indefinitely.
+                          # We don't set the counter to 0, because the automation would pick up the first scene next time,
+                          # instead of the last active one.
+                          - service: counter.set_value
+                            target:
+                              entity_id: "{{ scene_state_counter_helper }}"
+                            data:
+                              value: >-
+                                {% set new_counter_value = scene_state_counter_value % scenes_default|length %}
+                                {% if new_counter_value != 0 %}
+                                  {{ new_counter_value }}
+                                {% else %}
+                                  {{ scene_state_counter_value }}
+                                {% endif %}
+                          - if:
+                              - condition: template
+                                value_template: "{{ scene_state_counter_value == 0 }}"
+                                alias: Check if scene counter is currently 0
+                            then:
+                              # If the counter is 0 (which only happens when the automation runs the very first time with
+                              # a freh counter), we set it to 1 to make sure, the first scene is "stored" as the last active
+                              # scene.
+                              - service: counter.increment
+                                target:
+                                  entity_id: "{{ scene_state_counter_helper }}"
                 else:
                   - service: scene.turn_on
                     target:

--- a/automations/scene-cycle-button.yaml
+++ b/automations/scene-cycle-button.yaml
@@ -42,6 +42,12 @@ blueprint:
         entity:
           domain: light
           multiple: false
+    target_area:
+      name: Area
+      description: This area will be controlled by the button.
+      selector:
+        area:
+          multiple: false
     scenes:
       name: Scenes input select
       description: Define an input select with the scenes to cycle through on button press.
@@ -49,6 +55,15 @@ blueprint:
         entity:
           filter:
             - domain: input_select
+    button_press_timeout:
+      name: Button press timeout
+      description: The time window in which a button press after a previous button one switches to the next scene.
+      selector:
+        duration:
+      default:
+        hours: 0
+        minutes: 0
+        seconds: 3
     action_long_press:
       name: Action on long button press
       description: Define an action to perform when button is double-pressed.
@@ -70,15 +85,6 @@ blueprint:
       default: []
       selector:
         action:
-    button_press_timeout:
-      name: Button press timeout
-      description: The time window in which a button press after a previous button one switches to the next scene.
-      selector:
-        duration:
-      default:
-        hours: 0
-        minutes: 0
-        seconds: 3
 trigger:
   - device_id: !input button
     domain: zha
@@ -147,7 +153,7 @@ action:
                 metadata: {}
                 data: {}
                 target:
-                  entity_id: !input target_light
+                  area_id: "{{ target_area }}"
       - conditions:
           - condition: trigger
             id:
@@ -176,7 +182,7 @@ action:
                         data:
                           transition: 0
                         target:
-                          entity_id: !input target_light
+                          area_id: "{{ target_area }}"
                       - delay:
                           hours: 0
                           minutes: 0
@@ -187,7 +193,7 @@ action:
                         data:
                           transition: 0
                         target:
-                          entity_id: !input target_light
+                          area_id: "{{ target_area }}"
                     else:
                       - service: light.turn_on
                         data_template:
@@ -210,6 +216,7 @@ action:
 mode: restart
 variables:
   target_light: !input "target_light"
+  target_area: !input "target_area"
   scenes: !input "scenes"
   brightness: "{{state_attr(target_light, 'brightness')}}"
   action_long_press: !input "action_long_press"

--- a/automations/scene-cycle-button.yaml
+++ b/automations/scene-cycle-button.yaml
@@ -126,12 +126,12 @@ action:
                     enabled: true
                     alias: Check if time since last triggered is < than predefined value
                   - condition: template
-                    value_template: "{{ is_state( target_light , 'off' ) }}"
+                    value_template: "{{ is_light_off }}"
                     alias: Check if target lights are off
             then:
               - if:
                   - condition: template
-                    value_template: "{{ is_state( target_light , 'off' ) }}"
+                    value_template: "{{ is_light_off }}"
                     alias: Check if target lights are off
                 then:
                   - service: input_select.select_first
@@ -221,4 +221,7 @@ variables:
   brightness: "{{state_attr(target_light, 'brightness')}}"
   action_long_press: !input "action_long_press"
   button_press_timeout: !input "button_press_timeout"
-  button_press_timeout_seconds: "{{ [button_press_timeout.hours * 3600, button_press_timeout.minutes * 60, button_press_timeout.seconds] | sum }}"
+  target_lights: "{{ area_entities(target_area) | select('match', '^light\\..+') | list }}"
+  target_lights_on: "{{ expand(target_lights) | selectattr('state', 'eq', 'on') | list }}"
+  is_light_off: "{{ target_lights_on | count == 0 }}"
+  button_press_timeout_seconds: "{{ [button_press_timeout.hours * 3600, button_press_timeout.minutes * 60, button_press_timeout.seconds] | sum }}"

--- a/automations/scene-cycle-button.yaml
+++ b/automations/scene-cycle-button.yaml
@@ -157,8 +157,6 @@ action:
                       entity_id: "{{ scene_state_counter_helper }}"
             else:
               - service: light.turn_off
-                metadata: {}
-                data: {}
                 target:
                   area_id: "{{ target_area }}"
       - conditions:
@@ -185,7 +183,6 @@ action:
                         value_template: "{{ brightness > 253 }}"
                     then:
                       - service: light.turn_off
-                        metadata: {}
                         data:
                           transition: 0
                         target:
@@ -196,7 +193,6 @@ action:
                           seconds: 0
                           milliseconds: 100
                       - service: light.turn_on
-                        metadata: {}
                         data:
                           transition: 0
                         target:

--- a/automations/scene-cycle-hue-button.yaml
+++ b/automations/scene-cycle-hue-button.yaml
@@ -1,5 +1,5 @@
 blueprint:
-  name: Scene Cycle Button
+  name: Scene Cycle Button (Philips Hue)
   description:
     "Switch between multiple scenes on Philips Hue Smart button clicks.
     Supports long press, double press, and triple press actions as well."

--- a/automations/scene-cycle-hue-button.yaml
+++ b/automations/scene-cycle-hue-button.yaml
@@ -1,14 +1,38 @@
 blueprint:
   name: Scene Cycle Button (Philips Hue)
-  description:
-    "Switch between multiple scenes on Philips Hue Smart button clicks.
-    Supports long press, double press, and triple press actions as well."
+  description: |
+    Switch between multiple scenes on Philips Hue Smart button clicks.
+
+    ℹ️ **Version**: 2024.10.0
+
+    🐈‍⬛ **GitHub**: https://github.com/tmjssz/home-assistant-blueprints
+
+    ## ✨ Features
+
+    - Cycles through multiple scenes on consecutive button presses
+    - Start the cycle with the first scene or the last active scene when the lights are off
+    - Dim the target lights or turn off all lights completely on long button press
+    - Custom action when button is double-pressed or triple-pressed
+
+    ## How to use
+
+    1. Select the **button device** that will be used to cycle through the scenes.
+    2. Choose the **area** that contains the lights you want to control with the button.
+    3. Define a **counter helper** to store the number of clicks in a row for the selected button.
+    4. Select the **scenes** you want to cycle through on button press.
+    5. Optionally update the default value for the **button press timeout**.
+    6. Choose whether to start the cycle with the **first scene** or the **last active scene** when the lights are off.
+    7. Define the **action on long button press**.
+    8. Optionally define a custom **action on double button press**.
+    9. Optionally define a custom **action on triple button press**.
+
   domain: automation
-  author: Tim-Jonas Schwarz
+  author: Tim Schwarz
+
   input:
     button:
       name: Button
-      description: This button will be used to cycle through the scenes.
+      description: This button will be used to cycle through the scenes. Only Philips Hue Smart buttons are supported.
       selector:
         device:
           entity:
@@ -59,7 +83,7 @@ blueprint:
           multiple: true
     button_press_timeout:
       name: Button press timeout
-      description: The time window in which a button press after a previous button one switches to the next scene.
+      description: The time window in which a button press after a previous button one switches to the next scene. If the button is pressed after this time window, the cycle will start from the first scene again.
       selector:
         duration:
       default:
@@ -96,6 +120,7 @@ blueprint:
       default: []
       selector:
         action:
+
 trigger:
   - device_id: !input button
     domain: zha
@@ -121,7 +146,9 @@ trigger:
     type: remote_button_triple_press
     subtype: turn_on
     id: Triple press
+
 condition: []
+
 action:
   - choose:
       - conditions:
@@ -286,6 +313,7 @@ action:
             id:
               - Triple press
         sequence: !input action_triple_press
+
 mode: restart
 variables:
   target_area: !input "target_area"


### PR DESCRIPTION
This pull request involves significant changes to the automation blueprint for scene cycling using a Philips Hue button. The blueprint file has been renamed from `scene-cycle-button.yaml` to the more specific name `scene-cycle-hue-button.yaml` because it is only working with Philips Hue Smart Buttons. The changes provide enhanced functionality with clearer configuration options and support for different button actions.

## Key improvements

* **Input Configuration:**
  * Added a `target_area` selector for controlling lights in a defined area.
  * Introduced `scene_state_counter_helper` to store the number of clicks for scene cycling.
  * Added `scenes_default` which stores a list of scenes to be defined for cycling. That way the scenes can be defined directly in the automation config instead of having to create an input select with the scenes.
  * Added options `start_cycle_scene` to define whether to start with the first scene or the last active one on the first consecutive button press when lights are off.

* **Trigger and Action Logic:**
  * Improved logic for handling button presses with conditions to check the state of lights and scenes.
  * Added detailed sequences for handling long presses, double presses, and triple presses.
  * Introduced a counter mechanism to manage scene cycling more efficiently.
  * Improve dim feature: dims all lights in the target area, instead of just a single target light